### PR TITLE
rsquared - no intercept, per statsmodels

### DIFF
--- a/fastats/maths/ols.py
+++ b/fastats/maths/ols.py
@@ -103,10 +103,16 @@ def adjusted_r_squared(A, b):
     """
     The adjusted r-squared value
     """
-    ssr = sum_of_squared_residuals(A, b)
-    sst = total_sum_of_squares(A, b)
     n, k = A.shape
-    return 1.0 - (ssr / (n - k) / (sst / (n - 1)))
+    return 1 - (n - 1) / (n - k) * (1 - r_squared(A, b))
+
+
+def adjusted_r_squared_no_intercept(A, b):
+    """
+    The adjusted r-squared value in the case where no intercept term is present
+    """
+    n, k = A.shape
+    return 1 - n / (n - k) * (1 - r_squared_no_intercept(A, b))
 
 
 def fitted_values(A, b):

--- a/fastats/maths/ols.py
+++ b/fastats/maths/ols.py
@@ -88,6 +88,18 @@ def r_squared(A, b):
     return 1.0 - ssr / sst
 
 
+def r_squared_no_intercept(A, b):
+    """
+    The r-squared value (a.k.a. coefficient of determination) in the
+    case where A has no intercept, per statsmodels - compare the
+    slope-only model to a model that simply makes a constant
+    prediction of 0 for all observations
+    """
+    fitted = fitted_values(A, b)
+    sst = total_sum_of_squares(A, b)
+    return (fitted.T @ fitted) / sst
+
+
 def adjusted_r_squared(A, b):
     """
     The adjusted r-squared value

--- a/fastats/maths/ols.py
+++ b/fastats/maths/ols.py
@@ -96,8 +96,7 @@ def r_squared_no_intercept(A, b):
     prediction of 0 for all observations
     """
     fitted = fitted_values(A, b)
-    sst = total_sum_of_squares(A, b)
-    return (fitted.T @ fitted) / sst
+    return (fitted.T @ fitted) / (b.T @ b)
 
 
 def adjusted_r_squared(A, b):

--- a/tests/maths/test_ols_sklearn_diabetes.py
+++ b/tests/maths/test_ols_sklearn_diabetes.py
@@ -10,7 +10,8 @@ from fastats.maths.ols import (
     add_intercept, r_squared, sum_of_squared_residuals,
     fitted_values, residuals, adjusted_r_squared,
     standard_error, mean_standard_error_residuals,
-    t_statistic, r_squared_no_intercept
+    t_statistic, r_squared_no_intercept,
+    adjusted_r_squared_no_intercept
 )
 
 
@@ -111,6 +112,12 @@ class OLSModelWithoutIntercept(BaseOLS, OLSFitMeasuresTestMixin):
         A, b, model = self.get_fixtures()
         expected = model.rsquared
         output = r_squared_no_intercept(A, b)  # this is a replica of statsmodels / R behaviour
+        assert output == approx(expected)
+
+    def test_adjusted_r_squared(self):
+        A, b, model = self.get_fixtures()
+        expected = model.rsquared_adj
+        output = adjusted_r_squared_no_intercept(A, b)
         assert output == approx(expected)
 
 

--- a/tests/maths/test_ols_sklearn_diabetes.py
+++ b/tests/maths/test_ols_sklearn_diabetes.py
@@ -53,87 +53,92 @@ class OLSQRTests(BaseOLS, SklearnDiabetesOLS):
         self._func = ols_qr
 
 
-def test_add_intercept():
-    A = np.arange(21).reshape(7, 3)
-    output = add_intercept(A)
-    assert output.shape == (7, 4)
+class OLSFitMeasuresTestMixin:
 
-    expected = sm.add_constant(A)
-    assert np.allclose(output, expected)
+    @staticmethod
+    def fit_statsmodels_ols(A, b):
+        return sm.OLS(b, A).fit()
 
+    def get_fixtures(self):
+        return self._predictors, self._targets, self._model
 
-def get_data_and_fit_statsmodel(add_intercept_to_data_set=True):
-    data_set = datasets.load_diabetes()
-    A, b = data_set.data, data_set.target
+    def test_sum_of_squared_residuals(self):
+        A, b, model = self.get_fixtures()
+        expected = model.ssr
+        output = sum_of_squared_residuals(A, b)
+        assert output == approx(expected)
 
-    if add_intercept_to_data_set:
-        A = add_intercept(A)
+    def test_fitted_values(self):
+        A, b, model = self.get_fixtures()
+        expected = model.fittedvalues
+        output = fitted_values(A, b)
+        assert np.allclose(output, expected)
 
-    model = sm.OLS(b, sm.add_constant(A)).fit()
-    return A, b, model
+    def test_residuals(self):
+        A, b, model = self.get_fixtures()
+        expected = model.resid
+        output = residuals(A, b)
+        assert np.allclose(output, expected)
 
+    def test_standard_error(self):
+        A, b, model = self.get_fixtures()
+        expected = model.bse
+        output = standard_error(A, b)
+        assert np.allclose(output, expected)
 
-def test_r_squared():
-    A, b, model = get_data_and_fit_statsmodel()
-    expected = model.rsquared
-    output = r_squared(A, b)
-    assert output == approx(expected)
+    def test_mean_standard_error_residuals(self):
+        A, b, model = self.get_fixtures()
+        output = mean_standard_error_residuals(A, b)
+        expected = model.mse_resid
+        assert np.allclose(output, expected)
 
-
-def test_r_squared_no_intercept():
-    A, b, model = get_data_and_fit_statsmodel(False)
-    expected = model.rsquared
-    output = r_squared_no_intercept(A, b)
-    assert output == approx(expected)
-
-
-def test_adjusted_r_squared():
-    A, b, model = get_data_and_fit_statsmodel()
-    expected = model.rsquared_adj
-    output = adjusted_r_squared(A, b)
-    assert output == approx(expected)
-
-
-def test_sum_of_squared_residuals():
-    A, b, model = get_data_and_fit_statsmodel()
-    expected = model.ssr
-    output = sum_of_squared_residuals(A, b)
-    assert output == approx(expected)
+    def test_t_statistic(self):
+        A, b, model = self.get_fixtures()
+        expected = model.tvalues
+        output = t_statistic(A, b)
+        assert np.allclose(output, expected)
 
 
-def test_fitted_values():
-    A, b, model = get_data_and_fit_statsmodel()
-    expected = model.fittedvalues
-    output = fitted_values(A, b)
-    assert np.allclose(output, expected)
+class OLSModelWithoutIntercept(BaseOLS, OLSFitMeasuresTestMixin):
+
+    def setUp(self):
+        super().setUp()
+        self._targets = self._data.target
+        self._predictors = self._data.data
+        self._model = self.fit_statsmodels_ols(self._predictors, self._targets)
+
+    def test_r_squared(self):
+        A, b, model = self.get_fixtures()
+        expected = model.rsquared
+        output = r_squared_no_intercept(A, b)  # this is a replica of statsmodels / R behaviour
+        assert output == approx(expected)
 
 
-def test_residuals():
-    A, b, model = get_data_and_fit_statsmodel()
-    expected = model.resid
-    output = residuals(A, b)
-    assert np.allclose(output, expected)
+class OLSModelWithIntercept(BaseOLS, OLSFitMeasuresTestMixin):
 
+    def setUp(self):
+        super().setUp()
+        self._targets = self._data.target
+        self._predictors = sm.add_constant(self._data.data)
+        self._model = self.fit_statsmodels_ols(self._predictors, self._targets)
 
-def test_standard_error():
-    A, b, model = get_data_and_fit_statsmodel()
-    expected = model.bse
-    output = standard_error(A, b)
-    assert np.allclose(output, expected)
+    def test_add_intercept(self):
+        A = self._data.data
+        output = add_intercept(A)
+        expected = sm.add_constant(A)
+        assert np.allclose(output, expected)
 
+    def test_r_squared(self):
+        A, b, model = self.get_fixtures()
+        expected = model.rsquared
+        output = r_squared(A, b)
+        assert output == approx(expected)
 
-def test_mean_standard_error_residuals():
-    A, b, model = get_data_and_fit_statsmodel()
-    output = mean_standard_error_residuals(A, b)
-    expected = model.mse_resid
-    assert np.allclose(output, expected)
-
-
-def test_t_statistic():
-    A, b, model = get_data_and_fit_statsmodel()
-    expected = model.tvalues
-    output = t_statistic(A, b)
-    assert np.allclose(output, expected)
+    def test_adjusted_r_squared(self):
+        A, b, model = self.get_fixtures()
+        expected = model.rsquared_adj
+        output = adjusted_r_squared(A, b)
+        assert output == approx(expected)
 
 
 if __name__ == '__main__':

--- a/tests/maths/test_ols_sklearn_diabetes.py
+++ b/tests/maths/test_ols_sklearn_diabetes.py
@@ -10,7 +10,7 @@ from fastats.maths.ols import (
     add_intercept, r_squared, sum_of_squared_residuals,
     fitted_values, residuals, adjusted_r_squared,
     standard_error, mean_standard_error_residuals,
-    t_statistic
+    t_statistic, r_squared_no_intercept
 )
 
 
@@ -54,7 +54,6 @@ class OLSQRTests(BaseOLS, SklearnDiabetesOLS):
 
 
 def test_add_intercept():
-
     A = np.arange(21).reshape(7, 3)
     output = add_intercept(A)
     assert output.shape == (7, 4)
@@ -63,10 +62,13 @@ def test_add_intercept():
     assert np.allclose(output, expected)
 
 
-def get_data_and_fit_statsmodel():
+def get_data_and_fit_statsmodel(add_intercept_to_data_set=True):
     data_set = datasets.load_diabetes()
     A, b = data_set.data, data_set.target
-    A = add_intercept(A)  # Note addition of intercept
+
+    if add_intercept_to_data_set:
+        A = add_intercept(A)
+
     model = sm.OLS(b, sm.add_constant(A)).fit()
     return A, b, model
 
@@ -75,6 +77,13 @@ def test_r_squared():
     A, b, model = get_data_and_fit_statsmodel()
     expected = model.rsquared
     output = r_squared(A, b)
+    assert output == approx(expected)
+
+
+def test_r_squared_no_intercept():
+    A, b, model = get_data_and_fit_statsmodel(False)
+    expected = model.rsquared
+    output = r_squared_no_intercept(A, b)
     assert output == approx(expected)
 
 


### PR DESCRIPTION
Added the generally-accepted definition of r-squared for a model with no intercept.  Statsmodels (and R) automagically switch to using this 'under the hood' but I figured it might be better just to let the user decide when / whether to use it,