### PR TITLE
PCA - minor changes to allow nopython jit compilation

### DIFF
--- a/fastats/linear_algebra/pca.py
+++ b/fastats/linear_algebra/pca.py
@@ -16,10 +16,10 @@ def pca(data, components=4):
 
     >>> import numpy as np
     >>> x = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    >>> pca(x, components=1)
+    >>> np.abs(pca(x, components=1))
     array([[ 5.19615242],
            [ 0.        ],
-           [-5.19615242]])
+           [ 5.19615242]])
     """
     demeaned_data = demean(data)
     cov = demeaned_data.T @ demeaned_data

--- a/fastats/linear_algebra/pca.py
+++ b/fastats/linear_algebra/pca.py
@@ -16,10 +16,6 @@ def pca(data, components=4):
 
     >>> import numpy as np
     >>> x = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    >>> pca(x, components=2)
-    array([[  5.19615242e+00,  -4.44089210e-16],
-           [  0.00000000e+00,   0.00000000e+00],
-           [ -5.19615242e+00,   4.44089210e-16]])
     >>> pca(x, components=1)
     array([[ 5.19615242],
            [ 0.        ],

--- a/fastats/linear_algebra/pca.py
+++ b/fastats/linear_algebra/pca.py
@@ -1,13 +1,13 @@
 
-import numpy as np
-from numpy import cov
-from scipy.linalg import eigh
+from numpy.linalg import eigh
+
+from fastats.scaling import demean
 
 
 def pca(data, components=4):
     """
-    Principal Component Analysis using raw numpy
-    and scipy calls, returning the transformed data.
+    Principal Component Analysis, returning
+    the transformed data.
 
     This does not scale the data.
 
@@ -25,18 +25,13 @@ def pca(data, components=4):
            [ 0.        ],
            [-5.19615242]])
     """
-    mu = data.mean(axis=0)
+    demeaned_data = demean(data)
+    cov = demeaned_data.T @ demeaned_data
+    _, V = eigh(cov)  # returned in increasing eigenvalue order
 
-    # Have a think about this - this effectively copies
-    # the input just to demean. If we don't, we modify
-    # the input.
-    x = data - mu
-    r = cov(x, rowvar=False)
-    _, V = eigh(r)
-    V = np.flip(V, 1)
+    V = V.T[::-1].T[:, :components]
 
-    V = V[:, :components]
-    trans = np.dot(V.T, x.T).T
+    trans = (V.T @ demeaned_data.T).T
     return trans
 
 

--- a/fastats/scaling/__init__.py
+++ b/fastats/scaling/__init__.py
@@ -1,5 +1,5 @@
 
-from fastats.scaling.scaling import standard, min_max, rank, scale
+from fastats.scaling.scaling import standard, min_max, rank, scale, demean
 
 
 __all__ = [
@@ -7,4 +7,5 @@ __all__ = [
     'min_max',
     'rank',
     'scale',
+    'demean'
 ]

--- a/fastats/scaling/scaling.py
+++ b/fastats/scaling/scaling.py
@@ -28,7 +28,7 @@ def standard(A, ddof=0):
         raise ValueError('ddof must be either 0 or 1')
 
     n = A.shape[1]
-    res = empty_like(A, dtype=float)
+    res = empty_like(A, dtype=np_float64)
 
     for i in range(n):
         data_i = A[:, i]
@@ -50,7 +50,7 @@ def min_max(A):
     assert A.ndim > 1
 
     n = A.shape[1]
-    res = empty_like(A, dtype=float)
+    res = empty_like(A, dtype=np_float64)
 
     for i in range(n):
         data_i = A[:, i]
@@ -95,6 +95,22 @@ def rank(A):
         count[-1] = m
 
         res[:, i] = (count[dense] + count[dense - 1] + 1) / 2.0
+
+    return res
+
+
+def demean(A):
+    """
+    Subtract the mean from the supplied data column-wise.
+    """
+    assert A.ndim > 1
+
+    n = A.shape[1]
+    res = empty_like(A, dtype=np_float64)
+
+    for i in range(n):
+        data_i = A[:, i]
+        res[:, i] = data_i - mean(data_i)
 
     return res
 

--- a/tests/linear_algebra/test_pca.py
+++ b/tests/linear_algebra/test_pca.py
@@ -1,66 +1,22 @@
 
-from numba import jit
 import numpy as np
+from pytest import mark
 from sklearn.decomposition import PCA
-from sklearn.datasets import (
-    load_iris, load_diabetes, load_wine
-)
 
 from fastats.linear_algebra import pca
+from tests.data.datasets import SKLearnDataSets
 
 
-def test_pca_sklearn_iris():
-    iris = load_iris()
+@mark.parametrize('A', SKLearnDataSets)
+def test_pca_sklearn(A):
+    data = A.value.data
 
-    sk_pca = PCA(n_components=2)
-    sk_pca.fit(iris.data)
-    sk2 = sk_pca.transform(iris.data)
-
-    data2 = pca(iris.data, components=2)
-
-    assert np.allclose(np.abs(sk2), np.abs(data2))
-
-    sk_pca = PCA(n_components=4)
-    sk_pca.fit(iris.data)
-    sk4 = sk_pca.transform(iris.data)
-
-    data4 = pca(iris.data, components=4)
-
-    assert np.allclose(np.abs(sk4), np.abs(data4))
-
-
-def test_pca_sklearn_diabetes():
-    diab = load_diabetes()
-
-    sk_pca = PCA(n_components=2)
-    sk_pca.fit(diab.data)
-    sk2 = sk_pca.transform(diab.data)
-
-    data2 = pca(diab.data, components=2)
-
-    assert np.allclose(np.abs(sk2), np.abs(data2))
-
-    sk_pca = PCA(n_components=4)
-    sk_pca.fit(diab.data)
-    sk4 = sk_pca.transform(diab.data)
-
-    data4 = pca(diab.data, components=4)
-
-    assert np.allclose(np.abs(sk4), np.abs(data4))
-
-
-def test_pca_jit_sklearn_wine():
-    wine = load_wine()
-
-    pca_jit = jit(pca)
-
-    sk_pca = PCA(n_components=2)
-    sk_pca.fit(wine.data)
-    sk2 = sk_pca.transform(wine.data)
-
-    data2 = pca_jit(wine.data, components=2)
-
-    assert np.allclose(np.abs(sk2), np.abs(data2))
+    for n in range(1, data.shape[1] + 1):
+        sk_pca = PCA(n_components=n)
+        sk_pca.fit(data)
+        expected = sk_pca.transform(data)
+        output = pca(data, components=n)
+        assert np.allclose(np.abs(expected), np.abs(output))  # vector could legitimately be in 'opposite' direction
 
 
 if __name__ == '__main__':

--- a/tests/linear_algebra/test_pca.py
+++ b/tests/linear_algebra/test_pca.py
@@ -1,5 +1,6 @@
 
 import numpy as np
+from numba import jit
 from pytest import mark
 from sklearn.decomposition import PCA
 
@@ -16,6 +17,19 @@ def test_pca_sklearn(A):
         sk_pca.fit(data)
         expected = sk_pca.transform(data)
         output = pca(data, components=n)
+        assert np.allclose(np.abs(expected), np.abs(output))  # vector could legitimately be in 'opposite' direction
+
+
+@mark.parametrize('A', SKLearnDataSets)
+def test_pca_jit_sklearn(A):
+    data = A.value.data
+    pca_jit = jit(pca)
+
+    for n in range(1, data.shape[1] + 1):
+        sk_pca = PCA(n_components=n)
+        sk_pca.fit(data)
+        expected = sk_pca.transform(data)
+        output = pca_jit(data, components=n)
         assert np.allclose(np.abs(expected), np.abs(output))  # vector could legitimately be in 'opposite' direction
 
 

--- a/tests/linear_algebra/test_pca.py
+++ b/tests/linear_algebra/test_pca.py
@@ -8,29 +8,26 @@ from fastats.linear_algebra import pca
 from tests.data.datasets import SKLearnDataSets
 
 
-@mark.parametrize('A', SKLearnDataSets)
-def test_pca_sklearn(A):
-    data = A.value.data
-
+def check_versus_sklearn(data, fn):
     for n in range(1, data.shape[1] + 1):
         sk_pca = PCA(n_components=n)
         sk_pca.fit(data)
         expected = sk_pca.transform(data)
-        output = pca(data, components=n)
+        output = fn(data, components=n)
         assert np.allclose(np.abs(expected), np.abs(output))  # vector could legitimately be in 'opposite' direction
+
+
+@mark.parametrize('A', SKLearnDataSets)
+def test_pca_sklearn(A):
+    data = A.value.data
+    check_versus_sklearn(data, pca)
 
 
 @mark.parametrize('A', SKLearnDataSets)
 def test_pca_jit_sklearn(A):
     data = A.value.data
     pca_jit = jit(pca)
-
-    for n in range(1, data.shape[1] + 1):
-        sk_pca = PCA(n_components=n)
-        sk_pca.fit(data)
-        expected = sk_pca.transform(data)
-        output = pca_jit(data, components=n)
-        assert np.allclose(np.abs(expected), np.abs(output))  # vector could legitimately be in 'opposite' direction
+    check_versus_sklearn(data, pca_jit)
 
 
 if __name__ == '__main__':

--- a/tests/scaling/test_scaling.py
+++ b/tests/scaling/test_scaling.py
@@ -5,7 +5,7 @@ from pytest import mark, raises
 from scipy.stats import rankdata
 from sklearn.preprocessing import StandardScaler, MinMaxScaler
 
-from fastats.scaling.scaling import standard, min_max, rank, scale
+from fastats.scaling.scaling import standard, min_max, rank, scale, demean
 from tests.data.datasets import SKLearnDataSets
 
 
@@ -66,6 +66,14 @@ def test_rank_scale_versus_scipy(A):
         feature = data[:, i]
         expected = rankdata(feature)
         assert np.allclose(expected, output[:, i])
+
+
+@mark.parametrize('A', SKLearnDataSets)
+def test_demean(A):
+    data = A.value.data
+    expected = data - data.mean(axis=0)
+    output = demean(data)
+    assert np.allclose(expected, output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Small tweak to PCA to allow it to be njit compatible.  
Uses a new demean function (also njit compatible).  
Updated tests to use a wider collection of SKLearn samples and ranges of components.
Vaguely wondered if the components arg should be allowed to be None (i.e. all components) at some point, but left this for now.