### PR TITLE
Sporadically failing unit-test using parallel jit

### DIFF
--- a/fastats/scaling/scaling.py
+++ b/fastats/scaling/scaling.py
@@ -35,11 +35,11 @@ def standard(A, ddof=0):
         data_i = A[:, i]
         res[:, i] = (data_i - mean(data_i)) / std(data_i)
 
-    if ddof == 0:
-        return res
-    elif ddof == 1:
+    if ddof == 1:
         m = A.shape[0]
-        return res * sqrt((m - 1) / m)
+        res *= sqrt((m - 1) / m)
+
+    return res
 
 
 def min_max(A):
@@ -145,11 +145,11 @@ def standard_parallel(A, ddof=0):
         data_i = A[:, i]
         res[:, i] = (data_i - mean(data_i)) / std(data_i)
 
-    if ddof == 0:
-        return res
-    elif ddof == 1:
+    if ddof == 1:
         m = A.shape[0]
-        return res * sqrt((m - 1) / m)
+        res *= sqrt((m - 1) / m)
+
+    return res
 
 
 def min_max_parallel(A):

--- a/tests/core/test_windowed_pass.py
+++ b/tests/core/test_windowed_pass.py
@@ -115,8 +115,8 @@ def test_windowed_pass_nanmean():
 
 
 def ols_wrap(x):
-    a = x[:,:1]
-    b = x[:,1:]
+    a = x[:, :1]
+    b = x[:, 1:]
     return ols(a, b)[0][0]
 
 

--- a/tests/scaling/test_scaling.py
+++ b/tests/scaling/test_scaling.py
@@ -132,7 +132,13 @@ def test_standard_scale_parallel_with_bessel_correction_versus_sklearn(A):
 
     expected = df.apply(zscore).values
 
-    for fn in standard_parallel, standard_parallel_jit:
+    # Issues seen here running standard_parallel_jit using
+    # numba 0.35 on OS X.
+    # The standard parallel variant works fine, but the
+    # jit version is returning garbage float values for
+    # some (not all) data sets.
+    # Looks very much like a threading issue.
+    for fn in (standard_parallel, standard_parallel_jit):
         output = fn(data, ddof=1)
         assert np.allclose(expected, output)
 

--- a/tests/test_numba_parallel_issues.py
+++ b/tests/test_numba_parallel_issues.py
@@ -12,7 +12,7 @@ import numpy as np
 parallel = not (sys.platform == 'win32')
 
 
-@jit(nopython=True, parallel=True)
+@jit(nopython=True, parallel=parallel)
 def get(n):
     return np.ones((n,1), dtype=np.float64)
 

--- a/tests/test_numba_parallel_issues.py
+++ b/tests/test_numba_parallel_issues.py
@@ -1,9 +1,15 @@
 
+import sys
+
 from hypothesis import given
 from hypothesis.strategies import integers
 
 from numba import jit
 import numpy as np
+
+
+# Parallel not supported on 32-bit Windows
+parallel = not (sys.platform == 'win32')
 
 
 @jit(nopython=True, parallel=True)

--- a/tests/test_numba_parallel_issues.py
+++ b/tests/test_numba_parallel_issues.py
@@ -12,9 +12,11 @@ import numpy as np
 parallel = not (sys.platform == 'win32')
 
 
-@jit(nopython=True, parallel=parallel)
 def get(n):
     return np.ones((n,1), dtype=np.float64)
+
+
+get_jit = jit(nopython=True, parallel=parallel)(get)
 
 
 @given(integers(min_value=10, max_value=100000))
@@ -30,8 +32,8 @@ def test_all_ones(x):
     so we've taken the minimal repro from that issue
     and are using it as a unit-test here.
     """
-    result = get(x)
-    expected = np.ones((x, 1), dtype=np.float64)
+    result = get_jit(x)
+    expected = get(x)
     assert np.allclose(expected, result)
 
 

--- a/tests/test_numba_parallel_issues.py
+++ b/tests/test_numba_parallel_issues.py
@@ -13,7 +13,7 @@ parallel = not (sys.platform == 'win32')
 
 
 def get(n):
-    return np.ones((n,1), dtype=np.float64)
+    return np.ones((n, 1), dtype=np.float64)
 
 
 get_jit = jit(nopython=True, parallel=parallel)(get)

--- a/tests/test_numba_parallel_issues.py
+++ b/tests/test_numba_parallel_issues.py
@@ -1,0 +1,34 @@
+
+from hypothesis import given
+from hypothesis.strategies import integers
+
+from numba import jit
+import numpy as np
+
+
+@jit(nopython=True, parallel=True)
+def get(n):
+    return np.ones((n,1), dtype=np.float64)
+
+
+@given(integers(min_value=10, max_value=100000))
+def test_all_ones(x):
+    """
+    We found one of the scaling tests failing on
+    OS X with numba 0.35, but it passed on other
+    platforms, and passed consistently with numba
+    0.36.
+
+    The issue appears to be the same as numba#2609
+    https://github.com/numba/numba/issues/2609
+    so we've taken the minimal repro from that issue
+    and are using it as a unit-test here.
+    """
+    result = get(x)
+    expected = np.ones((x, 1), dtype=np.float64)
+    assert np.allclose(expected, result)
+
+
+if __name__ == '__main__':
+    import pytest
+    pytest.main([__file__])


### PR DESCRIPTION
Bug Report

- [X] Minimal repro in a test function


This unit-test is failing sporadically on OS X with numba 0.35, numpy 1.12 and 1.13. The `standard_parallel` function works fine (every time), but the `standard_parallel_jit` variant is occasionally returning garbage values.

This looks very much like a threading issue in numba, but i can't test on numba 0.36 as the conda packages won't install (dependency issue) on OS X.

Here's an example failure

```
tests/scaling/test_scaling.py:124 (test_standard_scale_parallel_with_bessel_correction_versus_sklearn[SKLearnDataSets.WINE])
A = <SKLearnDataSets.WINE: {'data': array([[  1.42300000e+01,   1.71000000e+00,   2.43000000e+00, ...,
          1.0400000...ids', 'nonflavanoid_phenols', 'proanthocyanins', 'color_intensity', 'hue', 'od280/od315_of_diluted_wines', 'proline']}>

    @mark.parametrize('A', SKLearnDataSets)
    def test_standard_scale_parallel_with_bessel_correction_versus_sklearn(A):
        data = A.value.data
        df = pd.DataFrame(data)
    
        def zscore(data):
            return (data - data.mean()) / data.std(ddof=1)
    
        expected = df.apply(zscore).values
    
        for fn in (standard_parallel, standard_parallel_jit):
            output = fn(data, ddof=1)
>           assert np.allclose(expected, output)
E           assert False
E            +  where False = <function allclose at 0x112d3ff28>(array([[ 1.51434077, -0.56066822,  0.23139979, ...,  0.36115849,\n         1.84272147,  1.01015939],\n       [ 0.2455968...882,  0.2956638 ],\n       [ 1.39116174,  1.57871176,  1.36136797, ..., -1.52009038,\n        -1.42492821, -0.59348626]]), array([[ -1.36311572e+057,  -1.36311572e+057,  -1.36311572e+057, ...,\n         -1.36311572e+057,  -1.36311572e+057,  -...174e+000,   1.57871176e+000,   1.36136797e+000, ...,\n         -1.52009038e+000,  -1.42492821e+000,  -5.93486258e-001]]))
E            +    where <function allclose at 0x112d3ff28> = np.allclose

test_scaling.py:137: AssertionError
```

you can see the e+057 values in the second array which are probably caused by low level issues in the thread pool.

This looks like a great catch from @rjenc29 's scaling unit-tests, but given that only one is failing, I'd like us to get more tests around this.

@fastats/core - could you please run this test/suite of tests using whatever platforms + numba versions available and let us know the results? Will test on gentoo later.

Thanks!
