### PR TITLE
Fixing 2/3 Codacy issues

### DIFF
--- a/fastats/maths/__init__.py
+++ b/fastats/maths/__init__.py
@@ -12,7 +12,6 @@ __all__ = [
     'logistic',
     'norm_pdf',
     'sum_sq_dev',
-    'add_intercept',
     'relu',
     'softplus',
 ]

--- a/tests/core/ast_transforms/test_basic_sanity.py
+++ b/tests/core/ast_transforms/test_basic_sanity.py
@@ -1,6 +1,4 @@
 
-import pytest
-
 from fastats.core.decorator import fs
 from tests import cube
 


### PR DESCRIPTION
Fixing 2 of the 3 Codacy issues that we can see [here](https://www.codacy.com/app/dave.willmer/fastats/issues/index).

* `add_intercept` was moved over to `linear_algebra`
* The double pytest import is trivial, the standard in the rest of the tests is to just import in the `if __name__ == 'main'`