### PR TITLE
Trivial changes to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/2199521147834d58b9f0e8e155c97309)](https://www.codacy.com/app/dave.willmer/fastats?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=fastats/fastats&amp;utm_campaign=Badge_Grade)
 
 
-A pure python library for benchmarked, scalable numerics, built using [numba](http://numba.pydata.org/).
+A pure python library for benchmarked, scalable numerics, built using [numba](https://numba.pydata.org/).
 
 ---
 
@@ -23,7 +23,7 @@ To fix (1) we need better algorithms, code which vectorises to SIMD instructions
 
 To fix (2) we need to focus on simpler code which is easier to debug.
 
-fastats (ie, fast-stats) tries to help with both of these by using [numba](http://numba.pydata.org/)
+fastats (ie, fast-stats) tries to help with both of these by using [numba](https://numba.pydata.org/)
 from [Anaconda](https://www.anaconda.com/) to JIT compile pure Python code to
 vectorised native code, whilst being trivial to run in pure Python mode for debugging.
 
@@ -46,7 +46,7 @@ result = newton_raphson(0.025, 1e-6, root=my_func)
 
 ```
 
-compared with scipy 0.12 ...
+compared with SciPy 0.12 ...
 
  ```bash
  >>> import scipy
@@ -59,16 +59,15 @@ compared with scipy 0.12 ...
 
 #### What does this show?
 
-Most high-level languages like Python/Lua/Ruby have a formal C-API which allows us to 'drop' down to native code easily (such as scipy shown above). However, not only is this time-consuming, error-prone and off-putting to many developers, but as you can see from the example above, the specialised C extensions do not automatically scale to larger data.
+Most high-level languages like Python/Lua/Ruby have a formal C-API which allows us to 'drop' down to native code easily (such as SciPy shown above). However, not only is this time-consuming, error-prone and off-putting to many developers, but as you can see from the example above, the specialised C extensions do not automatically scale to larger data.
 
-Through the use of [numba](http://numba.pydata.org/) to JIT-compile the entire function down to native code, we can quickly scale to much larger data sizes without leaving the simplicity of python.
+Through the use of [numba](https://numba.pydata.org/) to JIT-compile the entire function down to native code, we can quickly scale to much larger data sizes without leaving the simplicity of Python.
 
 #### What does fastats actually do?
 
 The secret is in the handling of the function arguments.
 
-When we write C-extensions to high-level languages, we are usually trying to speed up a certain algorithm which is taking too long. This works well for specialised libraries, however in this world of `big` data, the next step is usually `now i want to apply that function to this array of 10 million items`. This is where the C-extension / native library technique falls down.
-
+When we write C-extensions to high-level languages, we are usually trying to speed up a certain algorithm which is taking too long. This works well for specialised libraries, however in this world of `big` data, the next step is usually `now I want to apply that function to this array of 10 million items`. This is where the C-extension / native library technique falls down.
 
 C-extensions to high-level languages are necessarily limited by the defined API - ie, you can write a C function to take 3 floats, or 3 arrays of floats, but it's very difficult to deal with arbitrary inputs.
 
@@ -84,14 +83,13 @@ Requirements are not fixed yet, it's possible we'll require Python >= 3.6.
 
 For test requirements, take a look at [.travis.yml](.travis.yml) or [.appveyor.yml](.appveyor.yml).
 
-
 #### Contributing
 
-Please make sure you've read the contribution guide: [CONTRIBUTING.md](CONTRIBUTING.md)
+Please make sure you've read the contribution guide: [CONTRIBUTING.md](.github/CONTRIBUTING.md)
 
 In short, we use PRs for everything.
 
 
 #### Sponsors
 
-![Pico Software](http://pico-software.com/images/picosoftware.png | width=300)
+<img src="http://pico-software.com/images/picosoftware.png" width="300" alt="Pico Software" title="Pico Software"/>


### PR DESCRIPTION
A note of the fixes/changes:
* Trivial syntax/grammer changes, e.g. `i -> I`, `scipy -> SciPy`
* Making sure to use https links to numba
* Fixing broken image to Pico Software
* Fixing broken link to `CONTRIBUTING.md`