### PR TITLE
Adding tests for decorated functions passed as kwargs - potential bug?

### DIFF
--- a/tests/core/test_decorator.py
+++ b/tests/core/test_decorator.py
@@ -1,0 +1,19 @@
+
+from fastats.core.decorator import fs
+
+
+def test_decorated_func_kwargs():
+    @fs
+    def square(x):
+        return x ** 2
+
+    @fs
+    def func_that_takes_func_kwarg(arg, func=abs):
+        return func(arg)
+
+    func_that_takes_func_kwarg(4, func=square)
+
+
+if __name__ == '__main__':
+    import pytest
+    pytest.main([__file__])

--- a/tests/core/test_decorator.py
+++ b/tests/core/test_decorator.py
@@ -1,7 +1,9 @@
 
+import pytest
 from fastats.core.decorator import fs
 
 
+@pytest.mark.xfail
 def test_decorated_func_kwargs():
     @fs
     def square(x):
@@ -11,9 +13,19 @@ def test_decorated_func_kwargs():
     def func_that_takes_func_kwarg(arg, func=abs):
         return func(arg)
 
-    func_that_takes_func_kwarg(4, func=square)
+    result = func_that_takes_func_kwarg(4, func=square)
+    assert result == 16
 
+
+def test_no_decorator_func_kwargs():
+    def square(x):
+        return x ** 2
+
+    def func_that_takes_func_kwarg(arg, func=abs):
+        return func(arg)
+
+    result = func_that_takes_func_kwarg(4, func=square)
+    assert result == 16
 
 if __name__ == '__main__':
-    import pytest
     pytest.main([__file__])


### PR DESCRIPTION
Bug Report

- [x] Minimal repro in a test function

There's currently no coverage for [this chunk of logic](https://github.com/fastats/fastats/blob/238c5b8d0077601215c97bd191cde17e86f46905/fastats/core/decorator.py#L17) in the core decorator - I figured it would be nice to add tests.

To refresh memory, here's the code chunk I was looking to test:
```python
        # This deliberately mutates the kwargs.
        # We don't want to have a fs-decorated function
        # as a kwarg to another, so we undecorate it first.
        for k, v in kwargs.items():
            if hasattr(v, 'undecorated'):
                kwargs[k] = v.undecorated
```

I'm a little confused around the expected behaviour of `test_decorated_func_kwargs`, I would expect it to behave like standard Python would here, and execute the square function. I added a standard Python test too just for illustration, will (obviously) remove when/if it's ready to merge.

I would guess it's executing the compiled function here, instead of the one we're passing. Is it expected for this to not be supported? (Please let me know if I'm being silly, also!)

Happy to make any requested changes, branch is editable by maintainers too so no problem if anyone wants to tweak.