### PR TITLE
Uppercase python -> Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ var/
 *.egg
 
 # PyInstaller
-#  Usually these files are written by a python script from a template
+#  Usually these files are written by a Python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/2199521147834d58b9f0e8e155c97309)](https://www.codacy.com/app/dave.willmer/fastats?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=fastats/fastats&amp;utm_campaign=Badge_Grade)
 
 
-A pure python library for benchmarked, scalable numerics, built using [numba](https://numba.pydata.org/).
+A pure Python library for benchmarked, scalable numerics, built using [numba](https://numba.pydata.org/).
 
 [Fastats mailing list](https://groups.google.com/forum/#!forum/fastats)
 

--- a/tests/linear_algebra/test_lu.py
+++ b/tests/linear_algebra/test_lu.py
@@ -15,7 +15,7 @@ lu_jit = convert_to_jit(lu)
 class LUDecompValidator:
     """
     This is a mixin class which tests both
-    the raw python and the jit-compiled
+    the raw Python and the jit-compiled
     version of the `lu()` function.
     """
     A, L, U = None, None, None

--- a/tests/optimize/root_finding/test_newton_raphson.py
+++ b/tests/optimize/root_finding/test_newton_raphson.py
@@ -93,10 +93,10 @@ def test_non_converging():
     """
     Example also taken from literature/NewtonRaphson.pdf
     """
-    with raises(ZeroDivisionError): # Runtime Warning in python
+    with raises(ZeroDivisionError):  # Runtime Warning in Python
         _ = newton_raphson(5.0, 1e-6, root=tan_func)
 
-    # with warns(RuntimeWarning): # Runtime Warning in python
+    # with warns(RuntimeWarning):  # Runtime Warning in Python
     #     _ = newton_raphson(5.0, 1e-6, root=tan_func)
 
 


### PR DESCRIPTION
Minor updates to get rid of `python` in favour of `Python`.