### PR TITLE
Add pip-installable setup.py (with requirements inside)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,12 +16,10 @@ environment:
     - MINICONDA: "C:\\Miniconda36"
       CONDA_ENV_NAME: test_py_36_32bit_numpy_113
       CONDA_PYTHON: "python=3.6"
-      CONDA_NUMPY: "numpy=1.13"
 
     - MINICONDA: "C:\\Miniconda36-x64"
       CONDA_ENV_NAME: test_py_36_64bit_numpy_113
       CONDA_PYTHON: "python=3.6"
-      CONDA_NUMPY: "numpy=1.13"
 
 install:
   # If there is a newer build queued for the same PR, cancel this one.
@@ -50,21 +48,8 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  # Install dependencies
-  # TODO: should move to common yaml file in repo
-
-  - "conda install -y %CONDA_NUMPY%"
-  - "conda install -y scipy"
-  - "conda install -y scikit-learn"
-  - "conda install -y numba"
-  - "pip install hypothesis"
-  - "pip install pytest"
-  - "pip install pytest-cov"
-  - "pip install codecov"
-  - "pip install sphinx"
-  - "pip install sphinx_rtd_theme"
-  - "pip install statsmodels"
-  - "pip install httpie"  # for uploading test report xml
+  # Install dependencies using pip
+  - "pip install -e .[ci_test]"
 
 # Ignore the MSBuild nonsense
 build: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,6 +49,7 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   # Install dependencies using pip
+  - "pip install numpy"   # fix statsmodels install failing on windows when no numpy installed yet
   - "pip install -e .[ci_test]"
 
 # Ignore the MSBuild nonsense

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,7 @@
 [run]
 branch = True
+omit =
+    setup.py
 
 [report]
 fail_under = 98

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Some of the tests require extra libraries that are not required for normal
 installation.
 
 One way to develop `fastats` code is to work in a virtual environment and
-install `[all]` requirements bundle:
+install `[dev]` requirements bundle:
 
 ```bash
 $ pwd
@@ -59,7 +59,7 @@ $ pwd
 $ python3 -m pip install virtualenv --user
 $ python3 -m virtualenv venv
 $ . venv/bin/activate
-$ pip install -e .[all]
+$ pip install -e .[dev]
 ```
 
 Such install will ensure that all requirements are met, and that the changes

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -66,6 +66,16 @@ Such install will ensure that all requirements are met, and that the changes
 to `fastats` code are immediately visible.
 
 
+#### windows
+
+If you're on windows, the procedure should be analogous - except
+`activate` is a script that can be called directly.
+
+One problem that we've seen on windows is that `statsmodels` won't install
+unless `numpy` is installed first.  The solution is to run `pip install numpy`
+before `pip install -e .[dev]`.
+
+
 ## Code style
 
 We tend to follow [PEP8][pep8] for Python code style, with a few exceptions:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -65,6 +65,14 @@ $ pip install -e .[dev]
 Such install will ensure that all requirements are met, and that the changes
 to `fastats` code are immediately visible.
 
+#### IDEs
+
+Advanced IDEs, such as PyCharm, will allow you to create the virtualenv
+using GUI and pointing the project interpreter at it.  All you have to do then
+is fire up the terminal in the IDE, ensure you're in venv and run
+`pip install -e .[dev]`.  This should enable things like
+`right-click -> run py.test` etc.
+
 
 #### windows
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@ If you would like to contribute anything, fork the repo and open a Pull Request 
 
 The best way to ensure that git history is not jumbled up too much is to add an `upstream` remote:
 
-```
+```bash
 $ git clone ...your_fastats_fork_url...
 $ cd fastats
 $ git remote add upstream https://github.com/fastats/fastats
@@ -16,7 +16,7 @@ $ git remote add upstream https://github.com/fastats/fastats
 
 Then you can fetch from `upstream` remote and create new features on your fork easily:
 
-```
+```bash
 $ git fetch upstream
 $ git checkout -b my_awesome_branch upstream/master
 ```
@@ -40,6 +40,30 @@ questions on the [fastats mailing list](https://groups.google.com/forum/#!forum/
 - To submit a fix, open a PR with passing unittests + doctests.
 
 Simples :)
+
+
+## Installing requirements for development
+
+To ease dependency management, we rely on `setup.py` script to contain the
+requirements.
+
+Some of the tests require extra libraries that are not required for normal
+installation.
+
+One way to develop `fastats` code is to work in a virtual environment and
+install `[all]` requirements bundle:
+
+```bash
+$ pwd
+/your/github/checkout/of/fastats
+$ python3 -m pip install virtualenv --user
+$ python3 -m virtualenv venv
+$ . venv/bin/activate
+$ pip install -e .[all]
+```
+
+Such install will ensure that all requirements are met, and that the changes
+to `fastats` code are immediately visible.
 
 
 ## Code style

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,8 @@ os:
 python:
   - 3.6
   - 3.6-dev
-before_install:
-  - pip install numpy
-  - pip install scipy
-  - pip install scikit-learn
-  - pip install numba
-  - pip install hypothesis
-  - pip install pytest
-  - pip install pytest-cov
-  - pip install codecov
-  - pip install sphinx
-  - pip install sphinx_rtd_theme
-  - pip install statsmodels
+install:
+  - pip install -e .[ci_test,doc]
 script:
   - pytest
 #  - sphinx-build docs/source docs/build -W

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE
+include README.md
+include releases.md
+
+global-exclude *.ipynb

--- a/README.md
+++ b/README.md
@@ -76,11 +76,14 @@ C-extensions to high-level languages are necessarily limited by the defined API 
 
 #### Requirements
 
-- Python >= 3.5
-- Numba >= 0.33
+Python >= 3.6 only.
 
-Note: `fastats` is currently pre-release software.
-Requirements are not fixed yet, it's possible we'll require Python >= 3.6.
+See [setup.py](fastats/setup.py) - `install_requires` for installation requirements.
+
+The [contribution guide](.github/CONTRIBUTING.md) contains information on how to install
+development requirements.
+
+**Note**: `fastats` is currently pre-release software and has not been published yet.
 
 ##### Test requirements
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ C-extensions to high-level languages are necessarily limited by the defined API 
 
 Python >= 3.6 only.
 
-See [setup.py](fastats/setup.py) - `install_requires` for installation requirements.
+See [setup.py](setup.py) - `install_requires` for installation requirements.
 
 The [contribution guide](.github/CONTRIBUTING.md) contains information on how to install
 development requirements.

--- a/fastats/__init__.py
+++ b/fastats/__init__.py
@@ -4,6 +4,7 @@ from fastats.core.single_pass import single_pass
 from fastats.core.windowed_pass import windowed_pass, windowed_pass_2d
 from fastats.core.windowed_stateful_pass import windowed_stateful_pass
 from fastats.optimise.root_finding import newton_raphson
+from ._version import VERSION
 
 
 __all__ = [
@@ -14,3 +15,6 @@ __all__ = [
     'windowed_stateful_pass',
     'newton_raphson',
 ]
+
+
+__version__ = VERSION

--- a/fastats/_version.py
+++ b/fastats/_version.py
@@ -1,0 +1,5 @@
+# This is the authoritative version number which should be used everywhere,
+# including setup, packaging, documentation generation etc.
+#
+# Normally, this should be available as fastats.__version__
+VERSION = '2017.1.3rc0'

--- a/fastats/_version.py
+++ b/fastats/_version.py
@@ -2,4 +2,5 @@
 # including setup, packaging, documentation generation etc.
 #
 # Normally, this should be available as fastats.__version__
-VERSION = '2017.1.3rc0'
+VERSION = '2017.1rc0'
+

--- a/fastats/_version.py
+++ b/fastats/_version.py
@@ -1,3 +1,4 @@
+
 # This is the authoritative version number which should be used everywhere,
 # including setup, packaging, documentation generation etc.
 #

--- a/fastats/utilities/arrays.py
+++ b/fastats/utilities/arrays.py
@@ -1,5 +1,4 @@
 
-
 def is_2d(n):
     return len(n.shape) == 2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -91,8 +91,8 @@ setup_kwargs = dict(
 
 # CI-specific test utilities, e.g. travis, appveyor
 setup_kwargs['extras_require']['ci_test'] = (
-    setup_kwargs['tests_require'] +
-    [
+    setup_kwargs['tests_require']
+    + [
         'codecov',
         'httpie',
     ]
@@ -101,8 +101,8 @@ setup_kwargs['extras_require']['ci_test'] = (
 # All ("development") requirements, including docs generation and tests,
 # but no CI-specific ones
 setup_kwargs['extras_require']['dev'] = (
-    setup_kwargs['tests_require'] +
-    setup_kwargs['extras_require']['doc']
+    setup_kwargs['tests_require']
+    + setup_kwargs['extras_require']['doc']
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,109 @@
+
+import codecs
+import importlib.util
+from os import path
+
+from setuptools import setup, find_packages
+
+
+here = path.abspath(path.dirname(__file__))
+
+
+def read_utf8(filename):
+    """
+    Ensure consistent encoding
+    """
+    with codecs.open(path.join(here, filename), encoding='utf-8') as f:
+        return f.read()
+
+
+long_description = read_utf8('README.md')
+
+# import just the _version module, don't pull in any fastats dependencies
+spec = importlib.util.spec_from_file_location(
+    '_version', path.join(here, 'fastats', '_version.py')
+)
+version_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(version_module)
+
+version = version_module.VERSION
+
+
+setup_kwargs = dict(
+    name='fastats',
+    version=version,
+    description='A pure Python library for benchmarked, scalable numerics '
+                'using numba',
+    url='https://github.com/fastats/fastats',
+    author_email='fastats@googlegroups.com',
+
+    # Represents the body of text which users will see when they visit PyPI
+    long_description=long_description,
+
+    # For a list of valid classifiers, see
+    # https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+
+        'Topic :: Scientific/Engineering',
+
+        'Operating System :: OS Independent',
+
+        'License :: OSI Approved :: MIT License',
+
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.6',
+    ],
+
+    keywords='algorithmics ast linear-algebra numba numerics',
+    packages=find_packages(exclude=['tests', 'tests.*']),
+
+    setup_requires=[
+        'pytest-runner',    # to enable pytest for setup.py test via setup.cfg
+    ],
+
+    install_requires=[
+        'numba>=0.36.1',
+        'numpy',
+        'scipy',
+    ],
+
+    tests_require=[
+        'hypothesis',
+        'pytest',
+        'pytest-cov',
+        'scikit-learn',
+        'statsmodels',
+    ],
+
+    extras_require={
+        'doc': [    # documentation
+            'sphinx',
+            'sphinx_rtd_theme',
+        ],
+    },
+)
+
+
+# CI-specific test utilities, e.g. travis, appveyor
+setup_kwargs['extras_require']['ci_test'] = (
+    setup_kwargs['tests_require'] +
+    [
+        'codecov',
+        'httpie',
+    ]
+)
+
+# All ("development") requirements, including docs generation and tests,
+# but no CI-specific ones
+setup_kwargs['extras_require']['dev'] = (
+    setup_kwargs['tests_require'] +
+    setup_kwargs['extras_require']['doc']
+)
+
+
+setup(**setup_kwargs)


### PR DESCRIPTION
New Feature

- [x] Code conforms to style guide
- [ ] Doctests
- [ ] Unit-tests
- [x] Documentation
- [ ] New line item in [releases.md](releases.md)
- [ ] Info added to `literature` directory

---

`setup.py` should be pip-installable now and it embeds the requirements. All the requirements are embedded in `setup.py` and comparted into categories, such as `doc`, `dev` etc.

`python setup.py test` installs test requirements and runs `pytest` making testing trivial.

The contribution guide includes instructions how to install the development requirements in standard, portable and PyCharm-compatible way.