### PR TITLE
Fix doctests to work with numpy 1.14 and 1.13

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -102,14 +102,21 @@ We tend to follow [PEP8][pep8] for Python code style, with a few exceptions:
 #### Tests
 
 - Doctests should be minimal, and serve as API docs for the most common use cases.
+
   - For doctests, you should place this at the bottom of your module (followed by a blank line, ofc):
 
-  ```python
-  if __name__ == '__main__':
-      import pytest
-      pytest.main([__file__])
-  ```
-  This ensures that you can "run" every doctest in the module ad-hoc.
+    ```python
+    if __name__ == '__main__':
+        import pytest
+        pytest.main([__file__])
+    ```
+      
+    This ensures that you can "run" every doctest in the module ad-hoc.
+  
+  - Note that some doctests require special setup / options that are provided by pytest.
+    Because of this, they won't work on their own.
+    
+    See the `conftest.py` and `pytest.ini` files for more details.
 
 - Unittests should be exhaustive and should reside in the `tests` directory.
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,36 @@
+import numpy
+import pkg_resources
+import pytest
+
+
+# The first version of numpy that broke backwards compat and improved printing.
+#
+# We set the printing format to legacy to maintain our doctests' compatibility
+# with both newer and older versions.
+#
+# See: https://docs.scipy.org/doc/numpy/release.html#many-changes-to-array-printing-disableable-with-the-new-legacy-printing-mode
+#
+NUMPY_PRINT_ALTERING_VERSION = pkg_resources.parse_version('1.14.0')
+
+
+@pytest.fixture(autouse=True)
+def add_preconfigured_np(doctest_namespace):
+    """
+    Fixture executed for every doctest.
+
+    Injects pre-configured numpy into each test's namespace.
+
+    Note that even with this, doctests might fail due to the lack of full
+    compatibility when using ``numpy.set_printoptions(legacy='1.13')``.
+
+    Some of the whitespace issues can be fixed by NORMALIZE_WHITESPACE
+    doctest option, which is currently set in ``pytest.ini``.
+
+    See: https://github.com/numpy/numpy/issues/10383
+    """
+    current_version = pkg_resources.parse_version(numpy.__version__)
+
+    if current_version >= NUMPY_PRINT_ALTERING_VERSION:
+        numpy.set_printoptions(legacy='1.13')
+
+    doctest_namespace['np'] = numpy

--- a/conftest.py
+++ b/conftest.py
@@ -24,7 +24,7 @@ def add_preconfigured_np(doctest_namespace):
     Note that even with this, doctests might fail due to the lack of full
     compatibility when using ``numpy.set_printoptions(legacy='1.13')``.
 
-    Some of the whitespace issues can be fixed by NORMALIZE_WHITESPACE
+    Some of the whitespace issues can be fixed by ``NORMALIZE_WHITESPACE``
     doctest option, which is currently set in ``pytest.ini``.
 
     See: https://github.com/numpy/numpy/issues/10383

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+
 import numpy
 import pkg_resources
 import pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = --doctest-modules --doctest-glob='docs/source/*.rst' --cov . --cov-report term-missing --durations=5
+doctest_optionflags = NORMALIZE_WHITESPACE

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 
 import codecs
 import importlib.util

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup_kwargs = dict(
         'pytest-cov',
         'scikit-learn',
         'statsmodels',
+        'setuptools',   # for pkg_resources
     ],
 
     extras_require={


### PR DESCRIPTION
New Feature

- [x] Code conforms to style guide
- [ ] Doctests
- [ ] Unit-tests
- [x] Documentation
- [ ] New line item in [releases.md](releases.md)
- [ ] Info added to `literature` directory