### PR TITLE
Add dependencies versions to pytest header

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,7 @@ import numba
 import numpy
 import pkg_resources
 import pytest
+import scipy
 
 
 # The first version of numpy that broke backwards compat and improved printing.
@@ -39,6 +40,6 @@ def add_preconfigured_np(doctest_namespace):
 
 
 def pytest_report_header(config):
-    return 'Testing fastats using: NumPy {}, numba {}'.format(
-        numpy.__version__, numba.__version__
+    return 'Testing fastats using: Numba {}, NumPy {}, SciPy {}'.format(
+        numba.__version__, numpy.__version__, scipy.__version__,
     )

--- a/conftest.py
+++ b/conftest.py
@@ -39,6 +39,6 @@ def add_preconfigured_np(doctest_namespace):
 
 
 def pytest_report_header(config):
-    return "Testing fastats using: NumPy {}, numba {}".format(
+    return 'Testing fastats using: NumPy {}, numba {}'.format(
         numpy.__version__, numba.__version__
     )

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 
+import numba
 import numpy
 import pkg_resources
 import pytest
@@ -35,3 +36,9 @@ def add_preconfigured_np(doctest_namespace):
         numpy.set_printoptions(legacy='1.13')
 
     doctest_namespace['np'] = numpy
+
+
+def pytest_report_header(config):
+    return "Testing fastats using: NumPy {}, numba {}".format(
+        numpy.__version__, numba.__version__
+    )


### PR DESCRIPTION
Add new line to the pytest header detailing the libraries we depend on, to make diagnosing version problems easier.

Example:
```
============================= test session starts ==============================
platform linux -- Python 3.5.4, pytest-3.3.2, py-1.5.2, pluggy-0.6.0
Testing fastats using: Numba 0.36.2, NumPy 1.14.0, SciPy 1.0.0
rootdir: /home/.../fastats, inifile: pytest.ini
plugins: cov-2.5.1, hypothesis-3.44.21
collected 210 items
fastats/core/single_pass.py .                                            [  0%]
```