### PR TITLE
Adding in requirements and requirements-dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,10 @@
+numba>=0.37.0
+numpy
+scipy
+hypothesis
+pytest
+pytest-cov
+scikit-learn
+statsmodels
+setuptools
+mock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ statsmodels
 setuptools
 mock
 pandas
+patsy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ scikit-learn
 statsmodels
 setuptools
 mock
+pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numba>=0.37.0
+numpy
+scipy

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import codecs
 import importlib.util
 from os import path
 
-from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 
@@ -18,6 +17,13 @@ def read_utf8(filename):
     with codecs.open(path.join(here, filename), encoding='utf-8') as f:
         return f.read()
 
+
+def read_reqs(filename):
+    """
+    For a given requirements file, return the lines as a list of strings
+    """
+    with open(filename) as file:
+        return file.readlines()
 
 long_description = read_utf8('README.md')
 
@@ -69,11 +75,9 @@ setup_kwargs = dict(
         'pytest-runner',    # to enable pytest for setup.py test via setup.cfg
     ],
 
-    install_requires=[str(pip_req.req) for pip_req in
-                      parse_requirements('requirements.txt', session='setup')],
+    install_requires=read_reqs('requirements.txt'),
 
-    tests_require=[str(pip_req.req) for pip_req in
-                   parse_requirements('requirements-dev.txt', session='setup')],
+    tests_require=read_reqs('requirements-dev.txt'),
 
     extras_require={
         'doc': [    # documentation

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import codecs
 import importlib.util
 from os import path
 
+from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 
@@ -68,21 +69,11 @@ setup_kwargs = dict(
         'pytest-runner',    # to enable pytest for setup.py test via setup.cfg
     ],
 
-    install_requires=[
-        'numba>=0.37.0',
-        'numpy',
-        'scipy',
-    ],
+    install_requires=[str(pip_req.req) for pip_req in
+                      parse_requirements('requirements.txt', session='setup')],
 
-    tests_require=[
-        'hypothesis',
-        'pytest',
-        'pytest-cov',
-        'scikit-learn',
-        'statsmodels',
-        'setuptools',   # for pkg_resources
-        'mock',
-    ],
+    tests_require=[str(pip_req.req) for pip_req in
+                   parse_requirements('requirements-dev.txt', session='setup')],
 
     extras_require={
         'doc': [    # documentation


### PR DESCRIPTION
I spotted a 'to-do' for requirements.txt in the [project board](https://github.com/fastats/fastats/projects/1).

Added in a requirements and requirements-dev file, I've avoided pinning versions with the exception on numba due to https://github.com/numba/numba/issues/2609.