### PR TITLE
Adding pandas to tests_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup_kwargs = dict(
         'statsmodels',
         'setuptools',   # for pkg_resources
         'mock',
+        'pandas'
     ],
 
     extras_require={


### PR DESCRIPTION
CI on https://github.com/fastats/fastats/pull/60 and https://github.com/fastats/fastats/pull/61 is failing due to a missing pandas dep for some of the tests.

Let me know if I'm missing something obvious, but it looks like the Appveyor config is pulling from here.