### PR TITLE
Adding tests for core/ast_transforms/processor.py

### DIFF
--- a/tests/core/ast_transforms/test_processor.py
+++ b/tests/core/ast_transforms/test_processor.py
@@ -1,6 +1,7 @@
 
 import ast
 from collections import Iterable
+from textwrap import dedent
 
 from pytest import raises
 
@@ -8,19 +9,19 @@ from fastats.core.ast_transforms.processor import recompile, uncompile
 
 
 def test_recompile_happy_path():
-    func_as_string = '''
-def f(n):
-     # This is a comment
-     return n ** 2
-'''
+    func_as_string = dedent('''
+    def f(n):
+         # This is a comment
+         return n ** 2
+    ''')
     tree_module = ast.parse(func_as_string)
     recompile(tree_module, 'test_processor.py', 'exec')
 
 
 def test_recompile_no_func():
-    not_a_func = '''
-12 + 12 * 3
-'''
+    not_a_func = dedent('''
+    12 + 12 * 3
+    ''')
     tree_module = ast.parse(not_a_func)
     with raises(TypeError, match='Function body code not found'):
         recompile(tree_module, 'test_processor.py', 'exec')

--- a/tests/core/ast_transforms/test_processor.py
+++ b/tests/core/ast_transforms/test_processor.py
@@ -1,6 +1,6 @@
 
 import ast
-
+from collections import Iterable
 import pytest
 
 from fastats.core.ast_transforms.processor import recompile, uncompile
@@ -30,12 +30,7 @@ def test_uncompile_happy_path():
         return num ** 2
     _ = sq(4)  # For test coverage metrics
     result = uncompile(sq.__code__)
-    try:
-        iter(result)
-    except Exception as err:
-        raise Exception('''
-        Expected the result of uncompile to be iterable, error below:
-        {}'''.format(err))
+    assert isinstance(result, Iterable)
 
 
 def test_uncompile_lambdas():

--- a/tests/core/ast_transforms/test_processor.py
+++ b/tests/core/ast_transforms/test_processor.py
@@ -1,6 +1,8 @@
 
-import pytest
 import ast
+
+import pytest
+
 from fastats.core.ast_transforms.processor import recompile, uncompile
 
 

--- a/tests/core/ast_transforms/test_processor.py
+++ b/tests/core/ast_transforms/test_processor.py
@@ -9,7 +9,7 @@ def test_recompile_happy_path():
 def f(n):
      # This is a comment
      return n ** 2
-    '''
+'''
     tree_module = ast.parse(func_as_string)
     recompile(tree_module, 'test_processor.py', 'exec')
 

--- a/tests/core/ast_transforms/test_processor.py
+++ b/tests/core/ast_transforms/test_processor.py
@@ -51,8 +51,3 @@ def test_uncompile_bad_file_path():
     compiled = compile('21 + 21', '/this/file/doesnt/exist.py', 'exec')
     with raises(Exception, match='source code not available'):
         uncompile(compiled)
-
-
-if __name__ == 'main':
-    import pytest
-    pytest.main([__file__])

--- a/tests/core/ast_transforms/test_processor.py
+++ b/tests/core/ast_transforms/test_processor.py
@@ -2,7 +2,7 @@
 import ast
 from collections import Iterable
 
-import pytest
+from pytest import raises
 
 from fastats.core.ast_transforms.processor import recompile, uncompile
 
@@ -22,7 +22,7 @@ def test_recompile_no_func():
 12 + 12 * 3
 '''
     tree_module = ast.parse(not_a_func)
-    with pytest.raises(TypeError, match='Function body code not found'):
+    with raises(TypeError, match='Function body code not found'):
         recompile(tree_module, 'test_processor.py', 'exec')
 
 
@@ -37,21 +37,22 @@ def test_uncompile_happy_path():
 def test_uncompile_lambdas():
     lam_square = lambda x: x ** 2
     _ = lam_square(5)  # For test coverage metrics
-    with pytest.raises(TypeError, match='lambda functions not supported'):
+    with raises(TypeError, match='lambda functions not supported'):
         uncompile(lam_square.__code__)
 
 
 def test_uncompile_string():
     compiled = compile('21 + 21', '<string>', 'exec')
-    with pytest.raises(ValueError, match='code without source file not supported'):
+    with raises(ValueError, match='code without source file not supported'):
         uncompile(compiled)
 
 
 def test_uncompile_bad_file_path():
     compiled = compile('21 + 21', '/this/file/doesnt/exist.py', 'exec')
-    with pytest.raises(Exception, match='source code not available'):
+    with raises(Exception, match='source code not available'):
         uncompile(compiled)
 
 
 if __name__ == 'main':
+    import pytest
     pytest.main([__file__])

--- a/tests/core/ast_transforms/test_processor.py
+++ b/tests/core/ast_transforms/test_processor.py
@@ -28,6 +28,7 @@ def test_recompile_no_func():
 def test_uncompile_happy_path():
     def sq(num):
         return num ** 2
+    _ = sq(4)  # For test coverage metrics
     result = uncompile(sq.__code__)
     try:
         iter(result)
@@ -39,6 +40,7 @@ def test_uncompile_happy_path():
 
 def test_uncompile_lambdas():
     lam_square = lambda x: x ** 2
+    _ = lam_square(5)  # For test coverage metrics
     with pytest.raises(TypeError, match='lambda functions not supported'):
         uncompile(lam_square.__code__)
 

--- a/tests/core/ast_transforms/test_processor.py
+++ b/tests/core/ast_transforms/test_processor.py
@@ -1,0 +1,57 @@
+
+import pytest
+import ast
+from fastats.core.ast_transforms.processor import recompile, uncompile
+
+
+def test_recompile_happy_path():
+    func_as_string = '''
+def f(n):
+     # This is a comment
+     return n ** 2
+    '''
+    tree_module = ast.parse(func_as_string)
+    recompile(tree_module, 'test_processor.py', 'exec')
+
+
+def test_recompile_no_func():
+    not_a_func = '''
+12 + 12 * 3
+'''
+    tree_module = ast.parse(not_a_func)
+    with pytest.raises(TypeError, match='Function body code not found'):
+        recompile(tree_module, 'test_processor.py', 'exec')
+
+
+def test_uncompile_happy_path():
+    def sq(num):
+        return num ** 2
+    result = uncompile(sq.__code__)
+    try:
+        iter(result)
+    except Exception as err:
+        raise Exception('''
+        Expected the result of uncompile to be iterable, error below:
+        {}'''.format(err))
+
+
+def test_uncompile_lambdas():
+    lam_square = lambda x: x ** 2
+    with pytest.raises(TypeError, match='lambda functions not supported'):
+        uncompile(lam_square.__code__)
+
+
+def test_uncompile_string():
+    compiled = compile('21 + 21', '<string>', 'exec')
+    with pytest.raises(ValueError, match='code without source file not supported'):
+        uncompile(compiled)
+
+
+def test_uncompile_bad_file_path():
+    compiled = compile('21 + 21', '/this/file/doesnt/exist.py', 'exec')
+    with pytest.raises(Exception, match='source code not available'):
+        uncompile(compiled)
+
+
+if __name__ == 'main':
+    pytest.main([__file__])

--- a/tests/core/ast_transforms/test_processor.py
+++ b/tests/core/ast_transforms/test_processor.py
@@ -1,6 +1,7 @@
 
 import ast
 from collections import Iterable
+
 import pytest
 
 from fastats.core.ast_transforms.processor import recompile, uncompile


### PR DESCRIPTION
The 99% coverage was bothering me more than it should, so I opted to add some tests for the processor file.

I plan on hitting some of the TODO's in `AstProcessor` in the future so will add more comprehensive testing then.