### PR TITLE
Making Github mark .ipynb files as Python in repo details

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-language=Python

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.ipynb linguist-documentation
+*.ipynb linguist-language=Python

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.ipynb linguist-language=Python
+*.ipynb linguist-documentation


### PR DESCRIPTION
Github currently says that the repository is primarily a Python Notebook, which I don't feel is a good or accurate look, this PR will change .ipynb files to be marked as Python in the Github language parser. An alternative is to not consider .ipynb files into the repository code type info, open to doing this if core contributors feel it is more appropriate.

You can find out more about Github language parsing here - https://github.com/github/linguist

Left - Good, Right  -  Bad:
<img width="738" alt="screen shot 2018-08-02 at 22 57 33" src="https://user-images.githubusercontent.com/5992653/43613536-a54ebb1e-96a7-11e8-8a84-566c33b24b4b.png">
