### PR TITLE
Added numba to EWMA and the faster infinite history version of EWMA

### DIFF
--- a/fastats/maths/ewma.py
+++ b/fastats/maths/ewma.py
@@ -1,30 +1,98 @@
 
 import numpy as np
 
+from numba import jit
+from numba import float64
 
-def ewma(x, halflife):
+
+@jit((float64[:], float64), nopython=True, nogil=True)
+def ewma(arr_in, halflife):
+    r"""Exponentialy weighted moving average specified by a decay ``halflife``
+    to provide better adjustments for small windows via:
+
+        y[t] = (x[t] + (1-a)*x[t-1] + (1-a)^2*x[t-2] + ... + (1-a)^n*x[t-n]) /
+               (1 + (1-a) + (1-a)^2 + ... + (1-a)^n).
+
+    Parameters
+    ----------
+    arr_in : np.ndarray, float64
+        A single dimenisional numpy array
+    halflife : float64
+        Specify decay in terms of half-life,
+        :math:`\alpha = 1 - exp(log(0.5) / halflife),\text{ for } halflife > 0`
+
+    Returns
+    -------
+    np.ndarray
+        The EWMA vector, same length / shape as ``arr_in``
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> a = np.arange(5, dtype=float)
+    >>> exp = pd.DataFrame(a).ewm(halflife=2, adjust=True).mean()
+    >>> np.isclose(ewma(a, 2), exp.values.ravel())  # isclose for floating point err
+    True
     """
-    Exponentially Weighted Moving Average
-    It is expected that the numbers passed as x will be finite, halflife is
-    expected to be a finite, positive number.
-    >>> ewma(np.arange(5), halflife=2)
-    array([0.        , 0.58578644, 1.22654092, 1.91911977, 2.65947261])
+    n = arr_in.shape[0]
+    ewma = np.empty(n, dtype=float64)
+    decay_coefficient = 1 - np.exp(np.log(0.5) / halflife)
+    w = 1
+    ewma_old = arr_in[0]
+    ewma[0] = ewma_old
+    for i in range(1, n):
+        w += (1 - decay_coefficient)**i
+        ewma_old = ewma_old * (1 - decay_coefficient) + arr_in[i]
+        ewma[i] = ewma_old / w
+    return ewma
+
+
+@jit((float64[:], float64), nopython=True, nogil=True)
+def _ewma_infinite_hist(arr_in, halflife):
+    r"""Exponentialy weighted moving average specified by a decay ``halflife``
+    assuming infinite history via the recursive form:
+
+        (2) (i)  y[0] = x[0]; and
+            (ii) y[t] = a*x[t] + (1-a)*y[t-1] for t>0.
+
+    This method is less accurate that ``_ewma`` but
+    much faster:
+
+        In [1]: import numpy as np, bars
+           ...: arr = np.random.random(100000)
+           ...: %timeit bars._ewma(arr, 2)
+           ...: %timeit bars._ewma_infinite_hist(arr, 2)
+        3.74 ms ± 60.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
+        262 µs ± 1.54 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
+
+    Parameters
+    ----------
+    arr_in : np.ndarray, float64
+        A single dimenisional numpy array
+    halflife : float64
+        Specify decay in terms of half-life,
+        :math:`\alpha = 1 - exp(log(0.5) / halflife),\text{ for } halflife > 0`
+
+    Returns
+    -------
+    np.ndarray
+        The EWMA vector, same length / shape as ``arr_in``
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> a = np.arange(5, dtype=float)
+    >>> exp = pd.DataFrame(a).ewm(halflife=2, adjust=False).mean()
+    >>> np.array_equal(_ewma_infinite_hist(a, 2), exp.values.ravel())
+    True
     """
-    assert np.isfinite(halflife) and halflife > 0
-
-    decay_coefficient = np.exp(np.log(0.5) / halflife)
-    out = np.empty_like(x, dtype=np.float64)
-
-    for i in range(out.shape[0]):
-        if i == 0:
-            out[i] = x[i]
-            sum_prior = 1
-        else:
-            sum_i = sum_prior + np.power(decay_coefficient, i)
-            out[i] = (decay_coefficient * out[i - 1] * sum_prior + x[i]) / sum_i
-            sum_prior = sum_i
-
-    return out
+    n = arr_in.shape[0]
+    ewma = np.empty(n, dtype=float64)
+    decay_coefficient = 1 - np.exp(np.log(0.5) / halflife)
+    ewma[0] = arr_in[0]
+    for i in range(1, n):
+        ewma[i] = arr_in[i] * decay_coefficient + ewma[i - 1] * (1 - decay_coefficient)
+    return ewma
 
 
 def ewma_2d(x, halflife):


### PR DESCRIPTION
Added numba to ewma from https://stackoverflow.com/a/51392341/4013571
Also included the infinite history EWMA which is **much** faster.

Personally I prefer using span / window rather than halflife as it is more intuitive but I converted the `window` to `halflife` to match the existing repo style.

Lmk if this doesn't fit

 # New Feature

- [x] Code conforms to style guide
- [x] Doctests
- [ ] Unit-tests
- [x] Documentation
- [x] New line item in [releases.md](https://github.com/fastats/fastats/blob/master/releases.md)
- [ ] Info added to `literature` directory

 # Bug Report

- [x] Minimal repro in a test function